### PR TITLE
Fix Lua version compatibility in makemk.lua

### DIFF
--- a/ldk-resources/makemk.lua
+++ b/ldk-resources/makemk.lua
@@ -31,7 +31,7 @@
 --   src/foo.c, src/foo_bar.c, src/foo_baz.c
 --   → Grouped into 'foo' module with all three files
 --
---   src/bar.c, src/baz.c  
+--   src/bar.c, src/baz.c
 --   → Separate modules: 'bar' and 'baz'
 --
 -- The script also handles both C and C++ files, ensuring that the correct
@@ -113,10 +113,10 @@ printf('Generating mk/modules.mk...')
 -- Create mk/ directory if it doesn't exist
 local function mkdir_p(path)
     local cmd = format('mkdir -p "%s"', path)
-    local exit_code = os.execute(cmd)
-    if exit_code ~= 0 then
-        error(format('Failed to create directory: %s (exit code: %d)', path,
-                     exit_code))
+    local res = os.execute(cmd)
+    -- Lua 5.1 returns 0 on success, Lua 5.2+ returns true
+    if res ~= true and res ~= 0 then
+        error(format('Failed to create directory: %s', path))
     end
 end
 


### PR DESCRIPTION
This pull request updates the directory creation logic in `ldk-resources/makemk.lua` to improve compatibility with different Lua versions. The main change is to the `mkdir_p` function, ensuring it correctly checks the result of `os.execute` in both Lua 5.1 and 5.2+.

Error handling and compatibility improvements:

* Updated the `mkdir_p` function to handle the different return values of `os.execute` in Lua 5.1 (returns `0` on success) and Lua 5.2+ (returns `true` on success), improving cross-version compatibility and error reporting.