### PR TITLE
Change directory structure from 'lib/' to 'lua/' for Lua modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For advanced use cases or troubleshooting, see [INSTALL.md](INSTALL.md).
 - **`cross-platform-building.md`** - Cross-platform considerations: compiler detection, platform-specific flags
 
 ### Project Structure Memories
-- **`project-layout.md`** - Standard project structure: src/ for C code, lib/ for Lua modules, spec/ for tests
+- **`project-layout.md`** - Standard project structure: src/ for C code, lua/ for Lua modules, spec/ for tests
 - **`file-organization.md`** - File organization: naming conventions, directory hierarchies
 
 ### Testing and Quality

--- a/commands/ldk/setup.md
+++ b/commands/ldk/setup.md
@@ -46,4 +46,4 @@ After the script completes:
 ## Step 5: Final Instructions
 
 Tell the user:
-"Setup complete! Your build system supports Pure Lua projects, C/C++ extensions (.c/.cpp files), mixed projects, automatic compiler selection, and coverage instrumentation. Create src/, lib/, and bin/ directories as needed, then use 'luarocks make' to build."
+"Setup complete! Your build system supports Pure Lua projects, C/C++ extensions (.c/.cpp files), mixed projects, automatic compiler selection, and coverage instrumentation. Create src/, lua/, and bin/ directories as needed, then use 'luarocks make' to build."

--- a/ldk-resources/BUILD_SYSTEM_GUIDE.md
+++ b/ldk-resources/BUILD_SYSTEM_GUIDE.md
@@ -75,7 +75,7 @@ echo "  ${PACKAGE_NAME_UPPER}_COVERAGE=1 luarocks make rockspecs/$PACKAGE_NAME-d
 ## What This Provides
 
 - **Complete Lua Package System** - Supports pure Lua modules, C/C++ extensions, and command scripts
-- **Automatic File Discovery** - Scans `lib/`, `src/`, and `bin/` directories automatically
+- **Automatic File Discovery** - Scans `lua/`, `src/`, and `bin/` directories automatically
 - **LuaRocks Integration** - Seamless integration with LuaRocks package management
 - **Mixed Language Support** - Automatic handling of C and C++ files in same project
 - **Coverage Support** - Build with gcov instrumentation for C/C++ code and luacov for Lua code
@@ -158,7 +158,7 @@ After setup, you can further customize:
 This build system works with the following structure:
 ```
 your-project/
-├── lib/                    # Lua modules (.lua files)
+├── lua/                    # Lua modules (.lua files)
 │   ├── mypackage.lua      # Main module (optional)
 │   └── mypackage/         # Sub-modules (optional)
 │       └── helper.lua
@@ -173,9 +173,9 @@ your-project/
 
 ### Module Types
 
-**Pure Lua Package**: Only `lib/` directory with `.lua` files
+**Pure Lua Package**: Only `lua/` directory with `.lua` files
 **C/C++ Extension Package**: Only `src/` directory with `.c/.cpp` files  
-**Mixed Package**: Both `lib/` and `src/` directories
+**Mixed Package**: Both `lua/` and `src/` directories
 **Command Package**: Includes `bin/` directory with executable scripts
 
 ### Source File Handling

--- a/ldk-resources/Makefile
+++ b/ldk-resources/Makefile
@@ -14,7 +14,7 @@
 # - Installation paths must be correct for luarocks package management
 #
 # KEY FEATURES:
-# 1. AUTOMATIC DISCOVERY: Scans src/, lib/, bin/ directories automatically
+# 1. AUTOMATIC DISCOVERY: Scans src/, lua/, bin/ directories automatically
 # 2. PREFIX GROUPING: Groups C files by prefix (foo.c + foo_bar.c → single module)
 # 3. NESTED MODULES: Supports directory hierarchy (src/util/parser.c → util.parser)
 # 4. MIXED LANGUAGES: Handles C, C++, and Lua files in same project
@@ -22,7 +22,7 @@
 # 6. COVERAGE SUPPORT: Built-in support for code coverage analysis
 #
 # BENEFITS:
-# - Zero configuration: Just add files to src/, lib/, bin/ and they're built
+# - Zero configuration: Just add files to src/, lua/, bin/ and they're built
 # - Maintainable: No need to update Makefile when adding/removing source files
 # - Consistent: Enforces proper Lua module naming and structure conventions
 # - Portable: Works across different platforms via luarocks
@@ -127,12 +127,12 @@ $(info Discovering command scripts in bin/ directory...)
 CMD_SOURCES = $(shell find bin -name '*.lua' 2>/dev/null || true)
 CMD_TARGETS = $(patsubst bin/%.lua, $(BINDIR)/%, $(CMD_SOURCES))
 
-# Discover Lua module files in lib/ directory
-$(info Discovering Lua modules in lib/ directory...)
-LUASRCS = $(shell find lib -name '*.lua' 2>/dev/null || true)
-LUALIBS = $(patsubst lib/%,$(LUALIBDIR)/%,$(filter-out lib/$(PACKAGE_NAME).lua,$(LUASRCS)))
+# Discover Lua module files in lua/ directory
+$(info Discovering Lua modules in lua/ directory...)
+LUASRCS = $(shell find lua -name '*.lua' 2>/dev/null || true)
+LUALIBS = $(patsubst lua/%,$(LUALIBDIR)/%,$(filter-out lua/$(PACKAGE_NAME).lua,$(LUASRCS)))
 # Set MAINLIB for either Lua or C main module (but not both)
-MAINLIB = $(if $(wildcard lib/$(PACKAGE_NAME).lua),$(LUADIR)/$(PACKAGE_NAME).lua,$(if $(filter $(PACKAGE_NAME),$(MODULE_NAMES)),$(LIBDIR)/$(PACKAGE_NAME).$(LIB_EXTENSION)))
+MAINLIB = $(if $(wildcard lua/$(PACKAGE_NAME).lua),$(LUADIR)/$(PACKAGE_NAME).lua,$(if $(filter $(PACKAGE_NAME),$(MODULE_NAMES)),$(LIBDIR)/$(PACKAGE_NAME).$(LIB_EXTENSION)))
 
 ###########################################################################
 # C module definition generation and processing
@@ -219,13 +219,13 @@ LUALIBDIR = $(LUADIR)/$(PACKAGE_NAME)
 CLIBDIR = $(LIBDIR)/$(PACKAGE_NAME)
 
 # Module validation
-# Check for main module conflicts - prevent having both lib/package.lua and src/package.c
-HAS_MAIN_LUA = $(wildcard lib/$(PACKAGE_NAME).lua)
+# Check for main module conflicts - prevent having both lua/package.lua and src/package.c
+HAS_MAIN_LUA = $(wildcard lua/$(PACKAGE_NAME).lua)
 HAS_MAIN_C = $(filter $(PACKAGE_NAME),$(MODULE_NAMES))
 
 ifneq ($(HAS_MAIN_LUA),)
 ifneq ($(HAS_MAIN_C),)
-$(error Error: Both Lua main module (lib/$(PACKAGE_NAME).lua) and C main module (src/$(PACKAGE_NAME).c) exist. Please use only one main module type.)
+$(error Error: Both Lua main module (lua/$(PACKAGE_NAME).lua) and C main module (src/$(PACKAGE_NAME).c) exist. Please use only one main module type.)
 endif
 endif
 
@@ -291,15 +291,15 @@ define CLEANUP_BUILD_FILES
 	find src -name "*.gcda" -delete 2>/dev/null || true
 endef
 
-# Lua library files installation (lib/*.lua -> $(LUALIBDIR)/*)
-$(LUALIBDIR)/%: lib/%
+# Lua library files installation (lua/*.lua -> $(LUALIBDIR)/*)
+$(LUALIBDIR)/%: lua/%
 	$(INSTALL_FILES)
 
 # Main module installation (either Lua or C)
 ifneq ($(MAINLIB),)
 # Install Lua main module if it exists
-ifneq ($(wildcard lib/$(PACKAGE_NAME).lua),)
-$(MAINLIB): lib/$(PACKAGE_NAME).lua
+ifneq ($(wildcard lua/$(PACKAGE_NAME).lua),)
+$(MAINLIB): lua/$(PACKAGE_NAME).lua
 	$(INSTALL_FILES)
 else
 # Install C main module if it exists

--- a/ldk-resources/setup-makefile.sh
+++ b/ldk-resources/setup-makefile.sh
@@ -92,7 +92,7 @@ echo
 echo "Directory structure expected:"
 echo "  rockspecs/ - Rockspec files (created)"
 echo "  src/       - C/C++ source files (.c, .cpp)"
-echo "  lib/       - Lua library files (.lua)"
+echo "  lua/       - Lua library files (.lua)"
 echo "  bin/       - Command scripts (.lua, optional)"
 echo
 echo "Usage:"
@@ -100,7 +100,7 @@ echo "  luarocks make rockspecs/$PACKAGE_NAME-dev-1.rockspec    # Build and inst
 echo "  ${PACKAGE_NAME_UPPER}_COVERAGE=1 luarocks make rockspecs/$PACKAGE_NAME-dev-1.rockspec    # Build with coverage"
 echo
 echo "Supports:"
-echo "  - Pure Lua projects (lib/ only)"
+echo "  - Pure Lua projects (lua/ only)"
 echo "  - Pure C projects (.c files)"
 echo "  - Pure C++ projects (.cpp files)"
 echo "  - Mixed C/C++ projects"

--- a/memories/ldk-code-style.md
+++ b/memories/ldk-code-style.md
@@ -137,7 +137,7 @@ end
 ### Application Scope
 
 This convention applies to:
-- All Lua files under lib/
+- All Lua files under lua/
 - All C files under src/ (similar optimization with corresponding C functions)
 - Test files under test/
 

--- a/memories/ldk-coverage.md
+++ b/memories/ldk-coverage.md
@@ -24,7 +24,7 @@ return {
     
     -- Modules to include in coverage (adjust paths to match your project)
     include = {
-        "^lib/",           -- Include all modules in lib/ directory
+        "^lua/",           -- Include all modules in lua/ directory
         "^src/",           -- Include modules in src/ directory  
         "mymodule",        -- Include specific module
     },
@@ -81,7 +81,7 @@ Lines marked with `*0` indicate uncovered code that needs testing.
 
 ### Simple Module Projects
 **Single module**: Include pattern `"^mymodule$"`, exclude test directories (`"test/"` and `"spec/"`)  
-**Library projects**: Include `"^lib/"`, exclude test directories and external dependencies  
+**Library projects**: Include `"^lua/"`, exclude test directories and external dependencies  
 **Mixed C/Lua**: Include Lua paths only, exclude C extensions (use separate C coverage)  
 **Framework choice**: Exclude `"test/"` for testcase or `"spec/"` for busted (or both for mixed projects)
 

--- a/memories/ldk-index.md
+++ b/memories/ldk-index.md
@@ -16,7 +16,7 @@ Central reference point for all LDK memory files.
 
 ## Project Structure Memories
 
-@.claude/memories/project-layout.md - Standard Lua project structure: src/ for C code, lib/ for Lua modules, spec/ for tests, and proper file organization
+@.claude/memories/project-layout.md - Standard Lua project structure: src/ for C code, lua/ for Lua modules, spec/ for tests, and proper file organization
 @.claude/memories/file-organization.md - File organization best practices: module naming conventions, directory hierarchies, and separation of concerns
 
 ## Testing and Quality

--- a/memories/ldk-project-structure.md
+++ b/memories/ldk-project-structure.md
@@ -7,7 +7,7 @@ For test code guidelines, see @.claude/memories/ldk-test-guidelines.md
 
 **Path Structure Principle**: All directories mirror the `require()` module path structure. For `require('foo.bar.baz')`, files are organized as `<directory>/foo/bar/baz.<extension>`.
 
-- **Lua modules**: `lib/**/*.lua`
+- **Lua modules**: `lua/**/*.lua`
 - **C extensions**: `src/**/*.c`
 - **Tests**: `test/**/*_test.lua` (testcase) OR `spec/**/*_spec.lua` (busted) (one-to-one correspondence with modules)
 - **Benchmarks**: `bench/**/*_bench.lua` or `test/bench/**/*_bench.lua` (one-to-one correspondence)


### PR DESCRIPTION
This pull request updates the standard directory for Lua modules from `lib/` to `lua/` across the build system, documentation, code style, and coverage configuration. The changes ensure consistency in project structure and tooling, making it clear that Lua modules should reside in the `lua/` directory rather than `lib/`. This affects automatic file discovery, installation paths, code style guidelines, and coverage settings.

**Project Structure and Documentation Updates:**
* Updated all documentation and guides (`README.md`, `BUILD_SYSTEM_GUIDE.md`, `setup.md`, `ldk-index.md`, `ldk-project-structure.md`) to reference `lua/` as the directory for Lua modules instead of `lib/`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44) [[2]](diffhunk://#diff-c983d6c867c7d2d73de950374d091091c216b8f360d9ea396a8cadd384c42fedL49-R49) [[3]](diffhunk://#diff-286aab9607d5e2d27d827a1b7aeac52c4c97c9ea0df282bdbaecaf3f710af771L78-R78) [[4]](diffhunk://#diff-286aab9607d5e2d27d827a1b7aeac52c4c97c9ea0df282bdbaecaf3f710af771L161-R161) [[5]](diffhunk://#diff-286aab9607d5e2d27d827a1b7aeac52c4c97c9ea0df282bdbaecaf3f710af771L176-R178) [[6]](diffhunk://#diff-967db4389e2ed63ec0453fc14f7c26b8b801c89e83dde40e580db7c72b1c9ab9L19-R19) [[7]](diffhunk://#diff-bc1b6f1ff3bf6770c0149a283b29a43744df6b6eae33c5b1bc6eea3f5d35530bL10-R10)

**Build System and Automation Changes:**
* Modified `Makefile` and setup scripts to scan, install, and validate Lua modules in `lua/` instead of `lib/`, including main module conflict checks and installation rules. [[1]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL17-R25) [[2]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL130-R135) [[3]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL222-R228) [[4]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL294-R302) [[5]](diffhunk://#diff-e3b6583e75100ae858123e9e55d9e203bc15ae66579cc954e57c6aaa29a09cb9L95-R103)

**Code Style and Coverage Configuration:**
* Updated code style guidelines and coverage configuration to expect Lua modules under `lua/` and adjusted coverage include patterns accordingly. [[1]](diffhunk://#diff-9efdb5e7085a3153994a217cdb101dfe945f2b3bbccf7ce7116765e240812c8aL140-R140) [[2]](diffhunk://#diff-06f1c66ceb8d614ba63957a295a3e44561f44a9ac9e3d583aa3ebbc99be00090L27-R27) [[3]](diffhunk://#diff-06f1c66ceb8d614ba63957a295a3e44561f44a9ac9e3d583aa3ebbc99be00090L84-R84)