### PR TITLE
Refactor makemk.lua

### DIFF
--- a/ldk-resources/Makefile
+++ b/ldk-resources/Makefile
@@ -1,6 +1,6 @@
-###########################################################################
+##
 # Lua Package Build System with Automatic Module Discovery
-###########################################################################
+##
 #
 # PURPOSE:
 # This Makefile provides an automated build system for Lua packages that
@@ -31,27 +31,10 @@
 # This Makefile is designed to be used exclusively through 'luarocks make'.
 # Direct 'make' execution is prevented to ensure proper variable setup.
 #
-###########################################################################
-# Display build environment information
-# These variables are provided by luarocks via rockspec build_variables
-###########################################################################
-# PACKAGE_NAME    - Package name (e.g., "example")
-# LIB_EXTENSION   - Library extension (e.g., "so" on Linux/macOS, "dll" on Windows)
-# LUADIR          - Lua module installation directory (e.g., /usr/local/share/lua/5.1)
-# LIBDIR          - C library installation directory (e.g., /usr/local/lib/lua/5.1)
-# BINDIR          - Binary/script installation directory (e.g., /usr/local/bin)
-# CC              - C compiler command (e.g., "gcc", "clang")
-# CXX             - C++ compiler command (e.g., "g++", "clang++")
-# CFLAGS          - C compiler flags
-# CXXFLAGS        - C++ compiler flags
-# WARNINGS        - Warning flags
-# CPPFLAGS        - Preprocessor flags
-# LDFLAGS         - Linker flags
-# PLATFORM_LDFLAGS - Platform-specific linker flags
 
-$(info ========================================================================)
-$(info Phase 1: Build Environment Setup)
-$(info ========================================================================)
+##
+# C++ Compiler Configuration
+##
 # C++ compiler configuration
 # If CXX is not properly set, derive it from CC to inherit all SDK and platform settings
 # This ensures C++ compilation uses the same environment settings as C compilation
@@ -68,6 +51,29 @@ ifdef {{PACKAGE_NAME_UPPER}}_COVERAGE
 COVFLAGS = --coverage
 endif
 
+
+##
+# Display build environment information
+# These variables are provided by luarocks via rockspec build_variables
+##
+# PACKAGE_NAME    - Package name (e.g., "example")
+# LIB_EXTENSION   - Library extension (e.g., "so" on Linux/macOS, "dll" on Windows)
+# LUADIR          - Lua module installation directory (e.g., /usr/local/share/lua/5.1)
+# LIBDIR          - C library installation directory (e.g., /usr/local/lib/lua/5.1)
+# BINDIR          - Binary/script installation directory (e.g., /usr/local/bin)
+# CC              - C compiler command (e.g., "gcc", "clang")
+# CXX             - C++ compiler command (e.g., "g++", "clang++")
+# CFLAGS          - C compiler flags
+# CXXFLAGS        - C++ compiler flags
+# WARNINGS        - Warning flags
+# CPPFLAGS        - Preprocessor flags
+# LDFLAGS         - Linker flags
+# PLATFORM_LDFLAGS - Platform-specific linker flags
+# Macro to display build environment information
+define DISPLAY_BUILD_ENV
+$(info ========================================================================)
+$(info Phase 1: Build Environment Setup)
+$(info ========================================================================)
 $(info External Variables from luarocks:)
 $(info PACKAGE_NAME: $(PACKAGE_NAME))
 $(info LIB_EXTENSION: $(LIB_EXTENSION))
@@ -82,19 +88,30 @@ $(info LDFLAGS: $(LDFLAGS))
 $(info PLATFORM_LDFLAGS: $(PLATFORM_LDFLAGS))
 $(info COVFLAGS: $(COVFLAGS))
 $(info ========================================================================)
+endef
 
-###########################################################################
-# External variable validation
-# Validate required variables provided by luarocks
-###########################################################################
-ifndef PACKAGE_NAME
-$(error This Makefile must be used through 'luarocks make'. Please run 'luarocks make' instead of 'make' directly.)
+# Display build environment information only when not running clean
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
+$(eval $(call DISPLAY_BUILD_ENV))
 endif
 
-# Validate required external variables
-$(info Validating required external variables...)
-ifndef LIB_EXTENSION
-$(error Required variable LIB_EXTENSION is not set. Check rockspec install_variables.)
+##
+# External variable validation
+# Validate required variables provided by luarocks
+##
+# Allow 'make clean' to run without PACKAGE_NAME
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
+  ifndef PACKAGE_NAME
+    $(error This Makefile must be used through 'luarocks make'. Please run 'luarocks make' instead of 'make' directly.)
+  endif
+endif
+
+# Validate required external variables (skip for clean target)
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
+  $(info Validating required external variables...)
+  ifndef LIB_EXTENSION
+    $(error Required variable LIB_EXTENSION is not set. Check rockspec install_variables.)
+  endif
 endif
 # TEMPORARILY DISABLED FOR TESTING
 # ifndef LUADIR
@@ -108,27 +125,20 @@ endif
 # endif
 
 
-$(info DEBUG: Checking luarocks-provided variables...)
-$(info INST_PREFIX: $(INST_PREFIX))
-$(info INST_BINDIR: $(INST_BINDIR))
-$(info INST_LIBDIR: $(INST_LIBDIR))
-$(info INST_LUADIR: $(INST_LUADIR))
-$(info INST_CONFDIR: $(INST_CONFDIR))
-$(info LUA_BINDIR: $(LUA_BINDIR))
-$(info LUA_LIBDIR: $(LUA_LIBDIR))
-$(info LUA_INCDIR: $(LUA_INCDIR))
-
-
 ###########################################################################
 # Input file discovery and processing
 ###########################################################################
 # Discover command files in bin/ directory
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
 $(info Discovering command scripts in bin/ directory...)
+endif
 CMD_SOURCES = $(shell find bin -name '*.lua' 2>/dev/null || true)
 CMD_TARGETS = $(patsubst bin/%.lua, $(BINDIR)/%, $(CMD_SOURCES))
 
 # Discover Lua module files in lua/ directory
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
 $(info Discovering Lua modules in lua/ directory...)
+endif
 LUASRCS = $(shell find lua -name '*.lua' 2>/dev/null || true)
 LUALIBS = $(patsubst lua/%,$(LUALIBDIR)/%,$(filter-out lua/$(PACKAGE_NAME).lua,$(LUASRCS)))
 # Set MAINLIB for either Lua or C main module (but not both)
@@ -138,16 +148,22 @@ MAINLIB = $(if $(wildcard lua/$(PACKAGE_NAME).lua),$(LUADIR)/$(PACKAGE_NAME).lua
 # C module definition generation and processing
 # makemk.lua scans src/ directory and groups C/C++ files by prefix to create modules
 ###########################################################################
-ifneq ($(MAKECMDGOALS),install)
+ifeq ($(filter install clean,$(MAKECMDGOALS)),)
 $(info ========================================================================)
 $(info Phase 2: C Module Discovery and Processing)
 $(info ========================================================================)
 $(info Scanning src/ directory for C/C++ source files...)
-_ := $(shell lua makemk.lua)
+MAKEMK_OUTPUT := $(shell lua makemk.lua >&2 && echo "SUCCESS" || echo "FAILED")
+ifneq ($(MAKEMK_OUTPUT),SUCCESS)
+$(error makemk.lua failed to generate mk/modules.mk. Check the error messages above.)
+endif
 endif
 
 # Include module definitions (variables and MODULES list)
-$(info Loading generated module definitions from mk/modules.mk...)
+# Skip loading for clean target since we don't need module definitions
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
+  $(info Loading generated module definitions from mk/modules.mk...)
+endif
 #
 # MODULE VARIABLE DOCUMENTATION
 # =============================
@@ -197,10 +213,15 @@ $(info Loading generated module definitions from mk/modules.mk...)
 #   foo/bar.so -> foo_bar_OBJS, foo_bar_LINK, foo_bar_LIBS
 #   foo/qux.so -> foo_qux_OBJS, foo_qux_LINK, foo_qux_LIBS
 #
-include mk/modules.mk
+# Only include modules.mk if not running clean target
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
+  -include mk/modules.mk
+endif
 
 # Generate target variables and paths from C module definitions
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
 $(info Generating build targets and installation paths...)
+endif
 # MODULE_NAMES: extract just the filename (util, helper)
 MODULE_NAMES = $(foreach mod,$(MODULES),$(notdir $(mod)))
 # MODULE_TARGETS: convert src/util/helper -> src/util/helper.$(LIB_EXTENSION) (same directory as .o files)
@@ -208,10 +229,12 @@ MODULE_TARGETS = $(addsuffix .$(LIB_EXTENSION),$(MODULES))
 # MODULE_LIBS: full installation paths for C libraries (excluding main module if it's C)
 MODULE_LIBS = $(patsubst src/%,$(CLIBDIR)/%,$(addsuffix .$(LIB_EXTENSION),$(filter-out src/$(PACKAGE_NAME),$(MODULES))))
 
-###########################################################################
+##
 # Configuration and validation
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
 $(info Configuring build environment and validating module setup...)
-###########################################################################
+endif
+##
 # Installation directory configuration
 # LUALIBDIR - Package-specific Lua library directory ($(LUADIR)/$(PACKAGE_NAME))
 # CLIBDIR   - Package-specific C library directory ($(LIBDIR)/$(PACKAGE_NAME))
@@ -229,26 +252,17 @@ $(error Error: Both Lua main module (lua/$(PACKAGE_NAME).lua) and C main module 
 endif
 endif
 
-###########################################################################
+##
 # Build targets
-###########################################################################
-.PHONY: all install clean show-vars
+##
+.PHONY: all install install-commands install-lualibs clean show-vars
 
 # Default target - build all C modules
 all: $(MODULE_TARGETS)
 
-# Clean target - remove all build artifacts
-clean:
-	rm -f $(MODULE_TARGETS)
-	# Clean up any .so files including nested ones
-	find . -name "*.so" -not -path "./src/*" -delete 2>/dev/null || true
-	$(CLEANUP_BUILD_FILES)
-	# Also remove .gcno files for complete cleanup
-	find src -name "*.gcno" -delete 2>/dev/null || true
-
-###########################################################################
+##
 # Compilation and linking rules
-###########################################################################
+##
 # Object file compilation rules
 %.o: %.c
 	$(CC) $(CFLAGS) $(WARNINGS) $(COVFLAGS) $(CPPFLAGS) -o $@ -c $<
@@ -273,9 +287,9 @@ define BUILD_MODULE
 	$(1) -o $@ $^ $(LDFLAGS) $(PLATFORM_LDFLAGS) $(COVFLAGS) $(2)
 endef
 
-###########################################################################
+##
 # Installation rules and macros
-###########################################################################
+##
 # Common installation macro - creates directory and copies file
 define INSTALL_FILES
 	@echo "Installing $< -> $@"
@@ -283,17 +297,6 @@ define INSTALL_FILES
 	@mkdir -p "$(@D)"
 	@install "$<" "$@"
 endef
-
-# Common cleanup macro - removes build artifacts (preserves .gcno files for coverage)
-define CLEANUP_BUILD_FILES
-	find src -name "*.so" -delete 2>/dev/null || true
-	find src -name "*.o" -delete 2>/dev/null || true
-	find src -name "*.gcda" -delete 2>/dev/null || true
-endef
-
-# Lua library files installation (lua/*.lua -> $(LUALIBDIR)/*)
-$(LUALIBDIR)/%: lua/%
-	$(INSTALL_FILES)
 
 # Main module installation (either Lua or C)
 ifneq ($(MAINLIB),)
@@ -318,8 +321,18 @@ $(BINDIR)/%: bin/%.lua
 	$(INSTALL_FILES)
 	@chmod +x $@
 
+# Command installation target
+install-commands: $(CMD_TARGETS)
+
+# Lua library files installation (lua/*.lua -> $(LUALIBDIR)/*)
+$(LUALIBDIR)/%: lua/%
+	$(INSTALL_FILES)
+
+# Lua library installation target
+install-lualibs: $(LUALIBS)
+
 # Main installation target - installs all discovered files
-install: $(CMD_TARGETS) $(LUALIBS) $(MAINLIB) $(MODULE_LIBS)
+install: install-commands install-lualibs $(MAINLIB) $(MODULE_LIBS)
 	@echo ""
 	@echo "DEBUG: Install phase environment variables:"
 	@echo "LUADIR: $(LUADIR)"
@@ -328,11 +341,11 @@ install: $(CMD_TARGETS) $(LUALIBS) $(MAINLIB) $(MODULE_LIBS)
 	@echo ""
 	@echo "Installation complete"
 	# Clean up build files in the source directory
-	$(CLEANUP_BUILD_FILES)
+	@$(MAKE) clean-objects
 
-###########################################################################
+##
 # Debug and utility targets
-###########################################################################
+##
 # Show all build variables - useful for debugging and verification
 show-vars:
 	@echo "=== External Variables ==="
@@ -354,3 +367,17 @@ show-vars:
 	@echo "MODULE_NAMES: $(MODULE_NAMES)"
 	@echo "MODULE_TARGETS: $(MODULE_TARGETS)"
 	@echo "MODULE_LIBS: $(MODULE_LIBS)"
+
+# Clean target - remove all build artifacts
+# Works independently without requiring any external variables
+clean-objects:
+	# Remove all libraries (.so/.dll) and object files
+	find src \( -name "*.so" -o -name "*.dll" -o -name "*.o" \) -delete 2>/dev/null || true
+	find lib \( -name "*.a" -o -name "*.o" \) -delete 2>/dev/null || true
+
+clean:
+	# Remove all coverage artifacts
+	find src \( -name "*.gcda" -o -name "*.gcno" \) -delete 2>/dev/null || true
+	find lib \( -name "*.gcda" -o -name "*.gcno" \) -delete 2>/dev/null || true
+	# Clean up build files in the source directory
+	@$(MAKE) clean-objects

--- a/ldk-resources/makemk.lua
+++ b/ldk-resources/makemk.lua
@@ -41,74 +41,7 @@ local concat = table.concat
 local sort = table.sort
 local format = string.format
 local stderr = io.stderr
-
-local function printf(...) stderr:write(format(...), '\n') end
-
---- get the list of directories and files in src/
---- @param dirpath string the path to the directory to search
---- @return table a list of directories with their files
-local function get_dirinfo(dirpath)
-    local dirs = {}
-    local command = format(
-                        [[find %s -type f \( -name %s \) 2>/dev/null || true]],
-                        dirpath, concat({'*.c', '*.cpp'}, ' -o -name '))
-
-    for pathname in io.popen(command):lines() do
-        -- split the file to dir, name
-        local dirname, filename = pathname:match('^(.-)([^/]+)$')
-        -- split the filename to name, ext
-        local name, ext = filename:match('^([^%.]+)%.([^%.]+)$')
-
-        local group = dirs[dirname]
-        if not group then
-            group = {dirname = dirname, names = {}, ext4name = {}}
-            dirs[dirname] = group
-            dirs[#dirs + 1] = group
-        end
-        group.names[#group.names + 1] = name
-        if group.ext4name[name] then
-            error(format(
-                      'Cannot have the same filename %s.(%s|%s) in the same directory %s',
-                      name, ext, group.ext4name[name], dirname))
-        end
-        group.ext4name[name] = ext
-    end
-
-    -- sort the directories by name
-    sort(dirs, function(a, b) return a.dirname < b.dirname end)
-    return dirs
-end
-
---- add a file to a group based on its prefix
---- @param filegrp table the file group to add to
---- @param name string the name of the file to add
---- @param ext string the extension of the file to add
-local function add_group(filegrp, name, ext)
-    for gname, grp in pairs(filegrp) do
-        -- if the file prefix matches the group name
-        if #gname < #name and name:sub(1, #gname) == gname then
-            -- add the file to the group
-            grp.srcs[#grp.srcs + 1] = name .. '.' .. ext
-            if ext == 'cpp' then
-                grp.linker = '$(CXX)'
-                grp.libs = '-lstdc++'
-            end
-            return
-        end
-    end
-
-    -- create a new group for the file
-    local grp = {srcs = {name .. '.' .. ext}, linker = '$(CC)', libs = ''}
-    if ext == 'cpp' then
-        grp.linker = '$(CXX)'
-        grp.libs = '-lstdc++'
-    end
-
-    filegrp[name] = grp
-end
-
-printf(string.rep('#', 80))
-printf('Generating mk/modules.mk...')
+stderr:setvbuf('no') -- disable buffering
 
 -- Create mk/ directory if it doesn't exist
 local function mkdir_p(path)
@@ -120,6 +53,162 @@ local function mkdir_p(path)
     end
 end
 
+--- add a file to a group based on its prefix
+--- @param group table the file group to add to
+--- @param src string the source path of the file to add
+--- @param name string the name of the file to add
+--- @param ext string the extension of the file to add
+local function group_by_prefix(group, src, name, ext)
+    for gname, grp in pairs(group) do
+        -- if the file prefix matches the group name
+        if #gname < #name and name:sub(1, #gname) == gname then
+            -- add the file to the group
+            grp.srcs[#grp.srcs + 1] = src
+            if ext == 'cpp' then
+                grp.linker = '$(CXX)'
+                if not grp.libs['-lstdc++'] then
+                    grp.libs['-lstdc++'] = true
+                    grp.libs[#grp.libs + 1] = '-lstdc++'
+                end
+            end
+            return
+        end
+    end
+
+    -- create a new group for the file
+    local grp = {srcs = {src}, linker = '$(CC)', libs = {}}
+    if ext == 'cpp' then
+        grp.linker = '$(CXX)'
+        grp.libs['-lstdc++'] = true
+        grp.libs[#grp.libs + 1] = '-lstdc++'
+    end
+    group[name] = grp
+end
+
+--- get the directory information
+--- @param dirs table a table to store directory information
+--- @param pathname string the path to the file
+local function get_dirinfo(dirs, pathname)
+    -- split the file to dir, name
+    local dirname, filename = pathname:match('^(.-)([^/]+)$')
+    -- split the filename to name, ext
+    local name, ext = filename:match('^([^%.]+)%.([^%.]+)$')
+    local dirinfo = dirs[dirname]
+
+    if not dirinfo then
+        dirinfo = {
+            dirname = dirname,
+            names = {},
+            ext4name = {},
+            src4name = {},
+            groups = {}
+        }
+        dirs[dirname] = dirinfo
+        dirs[#dirs + 1] = dirinfo
+    end
+
+    -- check for duplicate filenames
+    if dirinfo.ext4name[name] then
+        error(format(
+                  'Cannot have the same filename %s.(%s|%s) in the same directory %s',
+                  name, ext, dirinfo.ext4name[name], dirname))
+    end
+    -- add the file to the directory info
+    dirinfo.names[#dirinfo.names + 1] = name
+    dirinfo.ext4name[name] = ext
+    dirinfo.src4name[name] = pathname
+end
+
+--- get the list of directories and files in src/
+--- @param dirpath string the path to the directory to search
+--- @return table a list of directories with their files
+local function get_dirinfos(dirpath)
+    local dirs = {}
+    local command = format(
+                        [[find %s -type f \( -name %s \) 2>/dev/null || true]],
+                        dirpath, concat({'*.c', '*.cpp'}, ' -o -name '))
+
+    for pathname in io.popen(command):lines() do
+        -- process each file path
+        get_dirinfo(dirs, pathname)
+    end
+
+    -- sort the directories by name
+    sort(dirs, function(a, b) return a.dirname < b.dirname end)
+    -- group files by prefix
+    for _, dirinfo in ipairs(dirs) do
+        -- sort the names
+        sort(dirinfo.names)
+        for _, name in ipairs(dirinfo.names) do
+            group_by_prefix(dirinfo.groups, dirinfo.src4name[name], name,
+                            dirinfo.ext4name[name])
+        end
+    end
+
+    return dirs
+end
+
+--- create a target for the module as the Makefile fragment.
+--- e.g.
+---   foo_SRCS = src/foo1.c src/foo2.cpp
+---   foo_OBJS = $(foo_SRCS:.cpp=.o)
+---   foo_OBJS := $(foo_OBJS:.c=.o)
+---   foo_LINK = $(CXX)
+---   foo_LIBS = -lstdc++
+---
+--- @param dirname string the directory name
+--- @param gname string the group name
+--- @param group table the group information
+--- @return table target the Makefile fragment for the module
+local function make_target(dirname, gname, group)
+    local module = dirname .. gname
+    -- Convert path to target name (src/foo/bar -> foo_bar)
+    local name = module:gsub('^src/', ''):gsub('/', '_')
+    local lines = ([[
+# target for @MODULE@
+@NAME@_SRC = @SRCS@
+@NAME@_OBJS = $(@NAME@_SRC:.c=.o)
+@NAME@_OBJS := $(@NAME@_OBJS:.cpp=.o)
+@NAME@_LINK = @LINKER@
+@NAME@_LIBS = @LIBS@]]):gsub('@([^@]+)@', {
+        MODULE = module,
+        NAME = name,
+        LINKER = group.linker,
+        LIBS = concat(group.libs, ' '),
+        SRCS = concat(group.srcs, ' ')
+    })
+    return {module = module, lines = lines}
+end
+
+--- create targets for each module in a specific directory
+--- @param dirpath string the path to the directory
+--- @return table a list of targets for the modules in the directory
+local function make_targets(dirpath)
+    if dirpath:find('^[^%w_]') then
+        error(format('Target directory location %q must not start with ' ..
+                         'a non-alphanumeric and non-underscore character',
+                     dirpath))
+    end
+    local dirinfos = get_dirinfos(dirpath)
+    local targets = {}
+    for _, dirinfo in ipairs(dirinfos) do
+        -- create a target for each group
+        for gname, group in pairs(dirinfo.groups) do
+            local target = make_target(dirinfo.dirname, gname, group)
+            targets[#targets + 1] = target
+        end
+    end
+    return targets
+end
+
+local function printf(...)
+    -- print formatted output to stdout
+    stderr:write(format(...), '\n')
+end
+
+printf(string.rep('#', 80))
+printf('Generating mk/modules.mk...')
+
 mkdir_p('mk')
 printf('Opening mk/modules.mk for writing...')
 local file, err = io.open('mk/modules.mk', 'w')
@@ -127,54 +216,32 @@ if not file then
     error(format('Failed to open mk/modules.mk for writing: %s', err))
 end
 
+-- Write header
 file:write([[
 # This file is generated by makemk.lua
 # Do not edit this file directly.
 # To regenerate this file, run `lua makemk.lua` from the project root.
-# Generated on: ]] .. os.date('%Y-%m-%d %H:%M:%S') .. '\n\n')
+# Generated on: ]] .. os.date('%Y-%m-%d %H:%M:%S'), '\n\n')
 
+-- Write module definitions and build rules
+file:write([[
+#
+# Module definitions and build rules
+#
+]])
+
+-- Process src/ directory for shared library modules
 local modules = {}
-local dirinfo = get_dirinfo('src/')
---- group files by their prefixes in each directory
-for _, dir in ipairs(dirinfo) do
-    -- sort the names by length
-    sort(dir.names, function(a, b) return #a < #b end)
-
-    -- create a group for the files in the directory
-    local filegrp = {}
-    for _, name in ipairs(dir.names) do
-        local ext = dir.ext4name[name]
-        add_group(filegrp, name, ext)
-    end
-
-    -- foo_SRCS = src/foo1.c src/foo2.cpp
-    -- foo_OBJS = $(foo_SRCS:.cpp=.o)
-    -- foo_OBJS := $(foo_OBJS:.c=.o)
-    -- foo_LINK = $(CXX)
-    -- foo_LIBS = -lstdc++
-    for gname, grp in pairs(filegrp) do
-        local module_path = dir.dirname .. gname
-        modules[#modules + 1] = module_path
-        -- Convert path to variable name (src/foo/bar -> foo_bar)
-        local var_name = module_path:gsub('^src/', ''):gsub('/', '_')
-        local lines = ([[
-@NAME@_SRC = @SRCS@
-@NAME@_OBJS = $(@NAME@_SRC:.c=.o)
-@NAME@_OBJS := $(@NAME@_OBJS:.cpp=.o)
-@NAME@_LINK = @LINKER@
-@NAME@_LIBS = @LIBS@]]):gsub('@([^@]+)@', {
-            NAME = var_name,
-            LINKER = grp.linker,
-            LIBS = grp.libs,
-            SRCS = dir.dirname .. concat(grp.srcs, ' ' .. dir.dirname)
-        })
-        printf('module: %s -> %s_* variables', module_path, var_name)
-        file:write(lines, '\n\n')
-    end
+local src_targets = make_targets('src/')
+for _, target in ipairs(src_targets) do
+    modules[#modules + 1] = target.module
+    printf('module %q target to be generated: %s_*', target.module,
+           target.module)
+    file:write(target.lines, '\n\n')
 end
-file:write(format('MODULES = %s', concat(modules, ' ')))
-file:write('\n')
-file:flush()
+-- Write module lists
+file:write(format('MODULES = %s', concat(modules, ' ')), '\n')
+
 file:close()
 printf('mk/modules.mk generated successfully.')
 printf(string.rep('#', 80))


### PR DESCRIPTION
This pull request refactors and improves the `ldk-resources/Makefile` to enhance clarity, modularity, and reliability of the build system. The main changes include reorganizing build phases, improving handling of build variables, and making the clean process safer and more independent. These updates make the Makefile easier to maintain and more robust when used with `luarocks make`.

**Build system organization and reliability:**

* Added explicit build phase separation, improved comments, and grouped related logic for easier readability and maintenance.
* Improved C++ compiler configuration to reliably inherit settings from the C compiler, ensuring consistent build environments.

**Variable handling and environment validation:**

* Centralized display of build environment information using a macro, shown only when relevant (not during clean), and improved validation of external variables to prevent accidental misuse outside `luarocks make`. [[1]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL51-L70) [[2]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaR91-R115)
* Removed redundant debug output and ensured environment checks are skipped for clean targets, making the clean process independent of external variables.

**Build and installation process improvements:**

* Modularized installation targets (`install-commands`, `install-lualibs`) and improved error handling for module generation, making the build and install phases more robust and easier to extend. [[1]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL141-R166) [[2]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaR324-R335)
* Refined inclusion of generated module definitions and build phase outputs to only run when necessary, reducing the risk of errors during cleaning or partial builds.

**Cleaning and artifact management:**

* Improved the clean process by splitting it into `clean-objects` (removes build artifacts) and `clean` (removes coverage files and calls `clean-objects`), making cleaning safer and independent of other build variables.
* Updated installation and cleanup logic to use new macros and targets, ensuring a more reliable and maintainable build lifecycle. [[1]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL232-R265) [[2]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL276-R292) [[3]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL287-L297) [[4]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL331-R348)