### PR TITLE
Add support for comment directives

### DIFF
--- a/ldk-resources/Makefile
+++ b/ldk-resources/Makefile
@@ -32,19 +32,6 @@
 # Direct 'make' execution is prevented to ensure proper variable setup.
 #
 
-##
-# C++ Compiler Configuration
-##
-# C++ compiler configuration
-# If CXX is not properly set, derive it from CC to inherit all SDK and platform settings
-# This ensures C++ compilation uses the same environment settings as C compilation
-ifndef CXX
-CXX = $(subst gcc,g++,$(subst clang,clang++,$(CC)))
-else ifeq ($(CXX),c++)
-# If CXX is just the basic 'c++', replace it with a derived version from CC
-CXX = $(subst gcc,g++,$(subst clang,clang++,$(CC)))
-endif
-
 # Build flags configuration
 # Coverage flags (enabled when {{PACKAGE_NAME_UPPER}}_COVERAGE is set)
 ifdef {{PACKAGE_NAME_UPPER}}_COVERAGE
@@ -259,33 +246,6 @@ endif
 
 # Default target - build all C modules
 all: $(MODULE_TARGETS)
-
-##
-# Compilation and linking rules
-##
-# Object file compilation rules
-%.o: %.c
-	$(CC) $(CFLAGS) $(WARNINGS) $(COVFLAGS) $(CPPFLAGS) -o $@ -c $<
-
-%.o: %.cpp
-	$(CXX) $(CXXFLAGS) $(WARNINGS) $(COVFLAGS) $(CPPFLAGS) -o $@ -c $<
-
-# Module linking rules
-# Static pattern rule with SECONDEXPANSION
-# - Uses $* (stem) to convert target path to variable name: util/helper -> util_helper
-# - SECONDEXPANSION allows dynamic variable name construction in prerequisites
-.SECONDEXPANSION:
-$(MODULE_TARGETS): src/%.$(LIB_EXTENSION): $$($$(subst /,_,$$*)_OBJS)
-	# Call BUILD_MODULE macro with: linker command, library flags
-	$(call BUILD_MODULE,$($(subst /,_,$*)_LINK),$($(subst /,_,$*)_LIBS))
-
-# Common module build rule (compile + link)
-# Parameters: $(1)=linker command, $(2)=library flags
-# Uses: $@=target, $^=all prerequisites
-define BUILD_MODULE
-	@mkdir -p $(@D)
-	$(1) -o $@ $^ $(LDFLAGS) $(PLATFORM_LDFLAGS) $(COVFLAGS) $(2)
-endef
 
 ##
 # Installation rules and macros


### PR DESCRIPTION
This pull request refactors the build system for the project by moving module build rule generation logic from the Makefile into the Lua script `makemk.lua`, and introduces support for per-source-file build flags via in-source directives. The changes improve maintainability, allow for more flexible module-specific and file-specific compilation/linking options, and unify static and dynamic library build rule generation.

**Build system refactoring and generation:**

* The logic for C++ compiler configuration and compilation/linking rules has been removed from `ldk-resources/Makefile` and is now generated dynamically by `makemk.lua`, ensuring consistent and maintainable build rules. [[1]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL35-L47) [[2]](diffhunk://#diff-61cf32607bffbc5801d4e8380615bfff2858baf9572cdeeac2ffbe676334b3aaL263-L289) [[3]](diffhunk://#diff-c8a9402b4f41a8aefa6185a7cd6a870854ef0ec49c51ffd95aebc90cc61f06e1R396-R440)

**Support for per-source-file build flags via directives:**

* Added parsing of special comment directives (e.g., `//@cflags:`, `//@cppflags:`, `//@ldflags:`) from source files, allowing developers to specify compiler and linker flags directly in source code. These flags are extracted and merged into the build configuration. [[1]](diffhunk://#diff-c8a9402b4f41a8aefa6185a7cd6a870854ef0ec49c51ffd95aebc90cc61f06e1R56-R199) [[2]](diffhunk://#diff-c8a9402b4f41a8aefa6185a7cd6a870854ef0ec49c51ffd95aebc90cc61f06e1R216) [[3]](diffhunk://#diff-c8a9402b4f41a8aefa6185a7cd6a870854ef0ec49c51ffd95aebc90cc61f06e1R229-R237)

**Module and target build rule improvements:**

* The Lua build system now supports both static (`lib/`) and dynamic (`src/`) library targets, generating appropriate Makefile fragments for each, and handles per-object compiler flags and linker flags for finer control. [[1]](diffhunk://#diff-c8a9402b4f41a8aefa6185a7cd6a870854ef0ec49c51ffd95aebc90cc61f06e1L144-R354) [[2]](diffhunk://#diff-c8a9402b4f41a8aefa6185a7cd6a870854ef0ec49c51ffd95aebc90cc61f06e1L197-R370) [[3]](diffhunk://#diff-c8a9402b4f41a8aefa6185a7cd6a870854ef0ec49c51ffd95aebc90cc61f06e1R396-R440)

**Internal code structure enhancements:**

* Introduced utility functions for merging flags and tables without duplicates, and restructured group and directory info to track flags per source and per group. [[1]](diffhunk://#diff-c8a9402b4f41a8aefa6185a7cd6a870854ef0ec49c51ffd95aebc90cc61f06e1R56-R199) [[2]](diffhunk://#diff-c8a9402b4f41a8aefa6185a7cd6a870854ef0ec49c51ffd95aebc90cc61f06e1R216)

**Backward compatibility and maintainability:**

* The generated Makefile now includes default variable definitions for tools and compilers, and generic compilation rules, ensuring compatibility and easier future maintenance.